### PR TITLE
feat: open register modal for redirected users

### DIFF
--- a/project/src/pages/RegisterPage.tsx
+++ b/project/src/pages/RegisterPage.tsx
@@ -5,7 +5,7 @@ import { User, Headphones, Building2, ChevronRight, Star, Zap, Crown, Clock, Cal
 import { UserType } from '../types';
 import AuthModal from '../components/auth/AuthModal';
 import EntityApplicationForm from '../components/entity/EntityApplicationForm';
-import { buildRedirectionState } from '../utils/redirectionUtils';
+import { buildRedirectionState, RedirectionState } from '../utils/redirectionUtils';
 import { useEntityStore } from '../stores/entityStore';
 import ReferralCodeInput from '../components/referral/ReferralCodeInput';
 import { useReferralStore } from '../stores/referralStore';
@@ -41,6 +41,18 @@ const RegisterPage: React.FC<RegisterPageProps> = () => {
       setRedirectToProfile(true);
     }
   }, [location]);
+
+  // Automatically open registration modal based on redirection state
+  useEffect(() => {
+    const state = location.state as RedirectionState | undefined;
+    if (state?.userType && state?.planId) {
+      setUserType(state.userType);
+      setAuthMode('register');
+      setShowAuthModal(true);
+      setIsRegistering(true);
+      setStep(2); // Skip role selection
+    }
+  }, [location.state]);
 
   const handleToggleForm = () => {
     setIsRegistering(!isRegistering);


### PR DESCRIPTION
## Summary
- auto-open register modal on /register when coming from subscription selection

## Testing
- `npm run lint` (fails: Invalid option '--ext')
- `npx eslint .` (fails: Cannot find package 'typescript-eslint')
- `npm run check-escapes` (fails: module not found)


------
https://chatgpt.com/codex/tasks/task_e_68929cac6b888332ab823d6916b257a1