### PR TITLE
feat: preserve selected plan in auth modal

### DIFF
--- a/project/src/components/auth/AuthModal.tsx
+++ b/project/src/components/auth/AuthModal.tsx
@@ -12,14 +12,16 @@ interface AuthModalProps {
   initialMode?: 'login' | 'register';
   userType?: UserType;
   redirectToProfile?: boolean;
+  planId?: string;
 }
 
 const AuthModal: React.FC<AuthModalProps> = ({
-  isOpen, 
-  onClose, 
+  isOpen,
+  onClose,
   initialMode = 'login',
   userType,
-  redirectToProfile
+  redirectToProfile,
+  planId
 }) => {
   const [mode, setMode] = useState<'login' | 'register'>(initialMode);
   const [isLoading, setIsLoading] = useState(false);
@@ -66,7 +68,7 @@ const AuthModal: React.FC<AuthModalProps> = ({
         // Build redirection state
         const redirectState = buildRedirectionState(
           mockUser.userType as UserType,
-          undefined, // No plan ID for mock login
+          planId,
           {
             userId: mockUser.id,
             redirectToProfile: true // Always redirect to profile after login

--- a/project/src/pages/RegisterPage.tsx
+++ b/project/src/pages/RegisterPage.tsx
@@ -26,6 +26,7 @@ const RegisterPage: React.FC<RegisterPageProps> = () => {
   const [referralCode, setReferralCode] = useState<string | null>(null);
   const [showReferralInput, setShowReferralInput] = useState(false);
   const [redirectToProfile, setRedirectToProfile] = useState(false);
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
 
   // Check for referral code in URL
   useEffect(() => {
@@ -35,10 +36,19 @@ const RegisterPage: React.FC<RegisterPageProps> = () => {
       setReferralCode(ref);
       setShowReferralInput(true);
     }
-    
-    // Check if we should redirect to profile after registration
-    if (location.state?.redirectToProfile) {
+
+    const state = location.state as {
+      redirectToProfile?: boolean;
+      planId?: string;
+      userType?: UserType;
+    };
+    if (state?.redirectToProfile) {
       setRedirectToProfile(true);
+    }
+    if (state?.planId) {
+      setUserType(state.userType || null);
+      setSelectedPlanId(state.planId);
+      setShowAuthModal(true);
     }
   }, [location]);
 
@@ -246,12 +256,13 @@ const RegisterPage: React.FC<RegisterPageProps> = () => {
       </motion.div>
 
       {/* Auth Modal */}
-      <AuthModal 
-        isOpen={showAuthModal} 
-        onClose={() => setShowAuthModal(false)} 
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
         initialMode={authMode}
         userType={userType}
         redirectToProfile={redirectToProfile}
+        planId={selectedPlanId || undefined}
       />
       
       {/* Entity Application Form */}


### PR DESCRIPTION
## Summary
- pass optional `planId` through AuthModal to persist chosen subscription
- read `planId` from navigation state in RegisterPage and forward to AuthModal
- include `planId` when building redirect state after auth

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68929ccd9bec8332849f38d77ef91f27